### PR TITLE
Issue : Boutons pour afficher le Pokemon en shiny #7

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ const rightBtn = document.getElementById("right-change-btn");
 const leftBtn = document.getElementById("left-change-btn");
 let dataArr = [];
 let currentIndex = 0;
+let isShiny = false;
 
 pokedexContainer.innerHTML = '<p>Chargement...</p>';
 
@@ -20,51 +21,80 @@ fetch("https://tyradex.vercel.app/api/v1/pokemon")
         pokedexContainer.innerHTML = `<p>Erreur : ${error.message}</p>`;
     });
 
-const displayPokemon = (index) =>{
+const toggleShiny = () => {
+    const pokemon = dataArr[currentIndex];
+    if (!pokemon.sprites.shiny) return;
+    
+    isShiny = !isShiny;
+    
+    const spriteImage = document.querySelector('.img-sprites');
+    const shinyButton = document.querySelector('.shiny-toggle-button');
+    
+    spriteImage.src = isShiny ? pokemon.sprites.shiny : pokemon.sprites.regular;
+    shinyButton.classList.toggle('shiny-active', isShiny);
+    shinyButton.setAttribute('aria-label', isShiny ? 'Afficher la version normale' : 'Afficher la version chromatique');
+};
+
+const displayPokemon = (index) => {
     const pokemon = dataArr[index];
+    isShiny = false;
     
     pokedexContainer.innerHTML = `
         <div class="pokemon-card">
-
-        <div class="img-description-container">
-
-           <div class="poke-description">
-               <h1 class="poke-name">${pokemon.name.fr}</h1>
-               <div class="p-container">
-                   <p class="poke-num">n°${pokemon.pokedex_id}</p>
-                   <p class="poke-generation">Generation&nbsp: ${pokemon.generation}</p>
-                   <p class="poke-category">${pokemon.category}</p>
-               </div>
-            </div>
-
-            <div class="poke-imgs">
-                <img class="img-sprites"src="${pokemon.sprites.regular}" alt="${pokemon.name.fr}">
-            </div>
-
-            <div class="poke-types">
-            ${pokemon.types.map(type => `<img src="${type.image}" alt="${type.name}" title="${type.name}">`).join('')}
-            ${pokemon.types.map(type => type.name).join(' / ')}
-            </div>
-
-            <div class="talents-stats-container">
-                <div class="poke-talents">
-                ${pokemon.talents.map(talent => `<p> Talents&nbsp: ${talent.name}</p>`).join('')}
+            <div class="img-description-container">
+                <div class="poke-description">
+                    <h1 class="poke-name">${pokemon.name.fr}</h1>
+                    <div class="p-container">
+                    <p class="poke-num">n°${pokemon.pokedex_id}</p>
+                    <p class="poke-generation">Generation&nbsp: ${pokemon.generation}</p>
+                    </div>
+                    <p class="poke-category">${pokemon.category}</p>
+                    <button class="shiny-toggle-button" type="button" aria-label="Afficher la version chromatique">
+                        <svg width="512" height="512" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+                            <defs>
+                                <radialGradient id="goldGradient" cx="40%" cy="40%" r="60%" fx="30%" fy="30%">
+                                <stop offset="0%" style="stop-color:#ffeebb;stop-opacity:1" />
+                                <stop offset="100%" style="stop-color:#daa520;stop-opacity:1" />
+                                </radialGradient>
+                                <path id="sparkle" d="M0,-10 C0,-3 3,0 10,0 C3,0 0,3 0,10 C0,3 -3,0 -10,0 C-3,0 0,-3 0,-10 Z" fill="white" />
+                            </defs>
+                            <circle cx="100" cy="100" r="95" fill="url(#goldGradient)" />
+                            <use href="#sparkle" x="100" y="60" transform="translate(100, 60) scale(3.5) translate(-100, -60)" />
+                            <use href="#sparkle" x="70" y="130" transform="translate(70, 130) scale(4.5) translate(-70, -130)" />
+                            <use href="#sparkle" x="150" y="90" transform="translate(150, 90) scale(2.5) translate(-150, -90)" />
+                        </svg>
+                    </button>
                 </div>
-            
-                <div class="poke-stats"> Statistiques&nbsp:
-                    <ul class="stats-list">
-                        <li class="s-hp">HP&nbsp: ${pokemon.stats.hp}</li>
-                        <li class="s-att">ATK&nbsp: ${pokemon.stats.atk}</li>
-                        <li class="s-def">DEF&nbsp: ${pokemon.stats.def}</li>
-                        <li class="s-spe-att">SPE ATK&nbsp: ${pokemon.stats.spe_atk}</li>
-                        <li class="s-spe-def">SPE DEF&nbsp: ${pokemon.stats.spe_def}</li>
-                        <li class="s-speed">SPEED&nbsp: ${pokemon.stats.vit}</li>
-                    </ul>
-               </div>
-             </div>
-            
+                <div class="poke-imgs">
+                    <img class="img-sprites" src="${pokemon.sprites.regular}" alt="${pokemon.name.fr}">
+                </div>
+                <div class="poke-types">
+                ${pokemon.types.map(type => `<img src="${type.image}" alt="${type.name}" title="${type.name}">`).join('')}
+                ${pokemon.types.map(type => type.name).join(' / ')}
+                </div>
+                <div class="talents-stats-container">
+                    <div class="poke-talents">
+                    ${pokemon.talents.map(talent => `<p> Talents&nbsp: ${talent.name}</p>`).join('')}
+                    </div>
+                    <div class="poke-stats"> Statistiques&nbsp:
+                        <ul class="stats-list">
+                            <li class="s-hp">HP&nbsp: ${pokemon.stats.hp}</li>
+                            <li class="s-att">ATK&nbsp: ${pokemon.stats.atk}</li>
+                            <li class="s-def">DEF&nbsp: ${pokemon.stats.def}</li>
+                            <li class="s-spe-att">SPE ATK&nbsp: ${pokemon.stats.spe_atk}</li>
+                            <li class="s-spe-def">SPE DEF&nbsp: ${pokemon.stats.spe_def}</li>
+                            <li class="s-speed">SPEED&nbsp: ${pokemon.stats.vit}</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
         </div>
     `;
+
+    const shinyButton = document.querySelector('.shiny-toggle-button');
+    if (shinyButton) {
+        shinyButton.addEventListener('click', toggleShiny);
+    }
 };
 
 rightBtn.addEventListener("click", () => {
@@ -82,8 +112,3 @@ leftBtn.addEventListener("click", () => {
     }
     displayPokemon(currentIndex);
 });
-
-
-
-
-

--- a/script.js
+++ b/script.js
@@ -47,8 +47,8 @@ const displayPokemon = (index) => {
                     <div class="p-container">
                     <p class="poke-num">n°${pokemon.pokedex_id}</p>
                     <p class="poke-generation">Generation&nbsp: ${pokemon.generation}</p>
-                    </div>
                     <p class="poke-category">${pokemon.category}</p>
+                    </div>
                     <button class="shiny-toggle-button" type="button" aria-label="Afficher la version chromatique">
                         <svg width="512" height="512" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
                             <defs>

--- a/styles.css
+++ b/styles.css
@@ -220,7 +220,7 @@ body {
     box-shadow: var(--shadow-2), var(--shadow-inset-light), var(--shadow-inset-dark);
 
     border-radius: 15px;
-
+    position: relative;
 }
 
 .poke-description h1 {
@@ -243,6 +243,52 @@ body {
     margin: 0;
     font-size: var(--font-size-text);
 
+}
+
+.shiny-toggle-button {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    
+    width: 32px;
+    height: 32px;
+    padding: 4px;
+    
+    background: rgba(255, 255, 255, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 50%;
+    cursor: pointer;
+    
+    transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.shiny-toggle-button:hover {
+    transform: translateY(-50%) scale(1.1);
+    background: rgba(255, 255, 255, 0.6);
+}
+
+.shiny-toggle-button:active {
+    transform: translateY(-50%) scale(0.95);
+}
+
+.shiny-toggle-button svg {
+    width: 100%;
+    height: 100%;
+    transition: opacity 0.2s ease;
+}
+
+.shiny-toggle-button svg circle {
+    fill: #b8b8b8;
+    transition: fill 0.2s ease;
+}
+
+.shiny-toggle-button.shiny-active svg {
+    fill: #ffd700;
+}
+
+.shiny-toggle-button.shiny-active svg circle {
+    fill: url(#a);
 }
 
 /*pok-imgs*/

--- a/styles.css
+++ b/styles.css
@@ -188,7 +188,6 @@ body {
     flex-direction: column;
     align-items: center;
     z-index: 2;
-
 }
 
 .img-description-container{
@@ -253,7 +252,7 @@ body {
     
     width: 32px;
     height: 32px;
-    padding: 4px;
+    padding: 1px;
     
     background: rgba(255, 255, 255, 0.4);
     border: 1px solid rgba(255, 255, 255, 0.5);
@@ -283,12 +282,8 @@ body {
     transition: fill 0.2s ease;
 }
 
-.shiny-toggle-button.shiny-active svg {
-    fill: #ffd700;
-}
-
 .shiny-toggle-button.shiny-active svg circle {
-    fill: url(#a);
+    fill: #ffd700;
 }
 
 /*pok-imgs*/

--- a/styles.css
+++ b/styles.css
@@ -523,6 +523,8 @@ font-size: var(--font-size-text-2);
   height:18px;
   width:18px;
   object-fit:cover;
+  outline: 1px solid #fff;
+  border-radius: 45%;
 }
 
 /* Couleurs types */

--- a/styles.css
+++ b/styles.css
@@ -523,8 +523,6 @@ font-size: var(--font-size-text-2);
   height:18px;
   width:18px;
   object-fit:cover;
-  outline: 1px solid #fff;
-  border-radius: 45%;
 }
 
 /* Couleurs types */


### PR DESCRIPTION
Ajout d'un bouton pour basculer entre la version chromatique et la version non chromatique du pokémon
Bouton fait à l'aide d'un SVG, bascule entre remplissage gris et jaune/doré pour indiquer si le sprite affiché est chromatique ou non
Repositionnement de la div de .p-container afin de conserver la mise en forme initiale de .poke-num .poke-generation et .poke-category sur la même ligne

Ajout d'une variable pour suivre état du bouton et sprite en chromatique ou non
Ajout de `const toggleShiny` pour modifier et suivre l'état du sprite et bouton
Correction d'indentation et de div non fermée (potentiellement moi qui ai cassé sans faire exprès, mais j'ai corrigé)
Repositionnement de certains éléments avec CSS position: absolute pour conserver le bon positionnement
Ajout des différentes classes nécessaires au bouton shiny et ses différents états